### PR TITLE
Further fixes to option interactions.

### DIFF
--- a/TradeDangerousGUI/EddbLinkDbUpdateForm.Designer.cs
+++ b/TradeDangerousGUI/EddbLinkDbUpdateForm.Designer.cs
@@ -113,6 +113,7 @@
             this.chkItem.Text = "Item";
             this.toolTips.SetToolTip(this.chkItem, "Regenerate Categories and Items using latest commodities.json dump.");
             this.chkItem.UseVisualStyleBackColor = true;
+            this.chkItem.CheckedChanged += new System.EventHandler(this.EventHandler_Item_CheckedChanged);
             // 
             // chkListings
             // 

--- a/TradeDangerousGUI/EddbLinkDbUpdateForm.cs
+++ b/TradeDangerousGUI/EddbLinkDbUpdateForm.cs
@@ -74,16 +74,6 @@ namespace TDHelper
         }
 
         /// <summary>
-        /// The event handler for all checked changed.
-        /// </summary>
-        /// <param name="sender">The sender object.</param>
-        /// <param name="e">The event arguments.</param>
-        private void EventHandler_All_CheckedChanged(object sender, EventArgs e)
-        {
-            SetAll();
-        }
-
-        /// <summary>
         /// The event handler for analyse clicked.
         /// </summary>
         /// <param name="sender">The sender object.</param>
@@ -91,16 +81,6 @@ namespace TDHelper
         private void EventHandler_Analyse_Click(object sender, EventArgs e)
         {
             AnalyseDatabase();
-        }
-
-        /// <summary>
-        /// The event handler for Clean checked changed.
-        /// </summary>
-        /// <param name="sender">The sender object.</param>
-        /// <param name="e">The event arguments.</param>
-        private void EventHandler_Clean_CheckedChanged(object sender, EventArgs e)
-        {
-            SetClean();
         }
 
         /// <summary>
@@ -114,16 +94,6 @@ namespace TDHelper
         }
 
         /// <summary>
-        /// The event handler for listings checked changed.
-        /// </summary>
-        /// <param name="sender">The sender object.</param>
-        /// <param name="e">The event arguments.</param>
-        private void EventHandler_Listings_CheckedChanged(object sender, EventArgs e)
-        {
-            SetListings();
-        }
-
-        /// <summary>
         /// The event handler for reset clicked.
         /// </summary>
         /// <param name="sender">The sender object.</param>
@@ -131,46 +101,6 @@ namespace TDHelper
         private void EventHandler_Reset_Click(object sender, EventArgs e)
         {
             ResetToDefault();
-        }
-
-        /// <summary>
-        /// The event handler for shipvend checked changed.
-        /// </summary>
-        /// <param name="sender">The sender object.</param>
-        /// <param name="e">The event arguments.</param>
-        private void EventHandler_Shipvend_CheckedChanged(object sender, EventArgs e)
-        {
-            SetShipvend();
-        }
-
-        /// <summary>
-        /// The event handler for skipvend checked changed.
-        /// </summary>
-        /// <param name="sender">The sender object.</param>
-        /// <param name="e">The event arguments.</param>
-        private void EventHandler_Skipvend_CheckedChanged(object sender, EventArgs e)
-        {
-            SetSkipvend();
-        }
-
-        /// <summary>
-        /// The event handler for solo checked changed.
-        /// </summary>
-        /// <param name="sender">The sender object.</param>
-        /// <param name="e">The event arguments.</param>
-        private void EventHandler_Solo_CheckedChanged(object sender, EventArgs e)
-        {
-            SetSolo();
-        }
-
-        /// <summary>
-        /// The event handler for station checked changed.
-        /// </summary>
-        /// <param name="sender">The sender object.</param>
-        /// <param name="e">The event arguments.</param>
-        private void EventHandler_Station_CheckedChanged(object sender, EventArgs e)
-        {
-            SetStation();
         }
 
         /// <summary>
@@ -184,6 +114,66 @@ namespace TDHelper
         }
 
         /// <summary>
+        /// The event handler for all checked changed.
+        /// </summary>
+        /// <param name="sender">The sender object.</param>
+        /// <param name="e">The event arguments.</param>
+        private void EventHandler_All_CheckedChanged(object sender, EventArgs e)
+        {
+            SetAll();
+        }
+
+        /// <summary>
+        /// The event handler for Clean checked changed.
+        /// </summary>
+        /// <param name="sender">The sender object.</param>
+        /// <param name="e">The event arguments.</param>
+        private void EventHandler_Clean_CheckedChanged(object sender, EventArgs e)
+        {
+            SetClean();
+        }
+
+        /// <summary>
+        /// The event handler for item checked changed.
+        /// </summary>
+        /// <param name="sender">The sender object.</param>
+        /// <param name="e">The event arguments.</param>
+        private void EventHandler_Item_CheckedChanged(object sender, EventArgs e)
+        {
+            SetItem();
+        }
+
+        /// <summary>
+        /// The event handler for station checked changed.
+        /// </summary>
+        /// <param name="sender">The sender object.</param>
+        /// <param name="e">The event arguments.</param>
+        private void EventHandler_Station_CheckedChanged(object sender, EventArgs e)
+        {
+            SetStation();
+        }
+
+        /// <summary>
+        /// The event handler for listings checked changed.
+        /// </summary>
+        /// <param name="sender">The sender object.</param>
+        /// <param name="e">The event arguments.</param>
+        private void EventHandler_Listings_CheckedChanged(object sender, EventArgs e)
+        {
+            SetListings();
+        }
+
+        /// <summary>
+        /// The event handler for shipvend checked changed.
+        /// </summary>
+        /// <param name="sender">The sender object.</param>
+        /// <param name="e">The event arguments.</param>
+        private void EventHandler_Shipvend_CheckedChanged(object sender, EventArgs e)
+        {
+            SetShipvend();
+        }
+
+        /// <summary>
         /// The event handler for upvend checked changed.
         /// </summary>
         /// <param name="sender">The sender object.</param>
@@ -191,6 +181,28 @@ namespace TDHelper
         private void EventHandler_Upvend_CheckedChanged(object sender, EventArgs e)
         {
             SetUpvend();
+        }
+
+        /// <summary>
+        /// The event handler for skipvend checked changed.
+        /// </summary>
+        /// <param name="sender">The sender object.</param>
+        /// <param name="e">The event arguments.</param>
+        private void EventHandler_Skipvend_CheckedChanged(object sender, EventArgs e)
+        {
+            SetSkipvend();
+            SetAll();
+        }
+
+        /// <summary>
+        /// The event handler for solo checked changed.
+        /// </summary>
+        /// <param name="sender">The sender object.</param>
+        /// <param name="e">The event arguments.</param>
+        private void EventHandler_Solo_CheckedChanged(object sender, EventArgs e)
+        {
+            SetSolo();
+            SetAll();
         }
 
         /// <summary>
@@ -346,63 +358,6 @@ namespace TDHelper
         }
 
         /// <summary>
-        /// Save any persistant settings to the settings object.
-        /// </summary>
-        private void SaveSettings()
-        {
-            if (chkSolo.Checked != MainForm.settingsRef.Solo)
-            {
-                MainForm.settingsRef.Solo = chkSolo.Checked;
-            }
-        }
-
-        /// <summary>
-        /// Set the controls for all.
-        /// </summary>
-        private void SetAll()
-        {
-            if (chkAll.Checked)
-            {
-                SetControlCheckedAndDisabled(chkItem);
-                SetControlCheckedAndDisabled(chkShip);
-                SetControlCheckedAndDisabled(chkShipvend);
-                SetControlCheckedAndDisabled(chkStation);
-                SetControlCheckedAndDisabled(chkSystem);
-                SetControlCheckedAndDisabled(chkUpgrade);
-                SetControlCheckedAndDisabled(chkUpvend);
-                SetControlCheckedAndDisabled(chkListings);
-            }
-            else
-            {
-                SetControlUncheckedAndEnabled(chkItem);
-                SetControlUncheckedAndEnabled(chkShip);
-                SetControlUncheckedAndEnabled(chkShipvend);
-                SetControlUncheckedAndEnabled(chkStation);
-                SetControlUncheckedAndEnabled(chkSystem);
-                SetControlUncheckedAndEnabled(chkUpgrade);
-                SetControlUncheckedAndEnabled(chkUpvend);
-                SetControlUncheckedAndEnabled(chkListings);
-            }
-        }
-
-        /// <summary>
-        /// Set the controls for clean.
-        /// </summary>
-        private void SetClean()
-        {
-            if (chkClean.Checked)
-            {
-                SetControlCheckedAndDisabled(chkAll);
-                SetControlCheckedAndDisabled(chkForce);
-            }
-            else
-            {
-                SetControlUncheckedAndEnabled(chkAll);
-                SetControlUncheckedAndEnabled(chkForce);
-            }
-        }
-
-        /// <summary>
         /// Set the specified control disabled and checked.
         /// </summary>
         /// <param name="control"></param>
@@ -433,6 +388,105 @@ namespace TDHelper
         }
 
         /// <summary>
+        /// Save any persistant settings to the settings object.
+        /// </summary>
+        private void SaveSettings()
+        {
+            if (chkSolo.Checked != MainForm.settingsRef.Solo)
+            {
+                MainForm.settingsRef.Solo = chkSolo.Checked;
+            }
+        }
+
+        /// <summary>
+        /// Set the controls for all.
+        /// </summary>
+        private void SetAll()
+        {
+            if (chkAll.Checked)
+            {
+                SetControlCheckedAndDisabled(chkItem);
+                SetControlCheckedAndDisabled(chkShip);
+                SetControlCheckedAndDisabled(chkStation);
+                SetControlCheckedAndDisabled(chkSystem);
+                SetControlCheckedAndDisabled(chkUpgrade);
+                if (!chkSkipvend.Checked)
+                {
+                    SetControlCheckedAndDisabled(chkShipvend);
+                    SetControlCheckedAndDisabled(chkUpvend);
+                }
+                if (!chkSolo.Checked)
+                {
+                    SetControlCheckedAndDisabled(chkListings);
+                }
+            }
+            else
+            {
+                SetControlUncheckedAndEnabled(chkItem);
+                SetControlUncheckedAndEnabled(chkShip);
+                SetControlUncheckedAndEnabled(chkStation);
+                SetControlUncheckedAndEnabled(chkSystem);
+                SetControlUncheckedAndEnabled(chkUpgrade);
+                if (!chkSkipvend.Checked)
+                {
+                    SetControlUncheckedAndEnabled(chkShipvend);
+                    SetControlUncheckedAndEnabled(chkUpvend);
+                }
+                if (!chkSolo.Checked)
+                {
+                    SetControlUncheckedAndEnabled(chkListings);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Set the controls for clean.
+        /// </summary>
+        private void SetClean()
+        {
+            if (chkClean.Checked)
+            {
+                SetControlCheckedAndDisabled(chkAll);
+                SetControlCheckedAndDisabled(chkForce);
+            }
+            else
+            {
+                SetControlUncheckedAndEnabled(chkAll);
+                SetControlUncheckedAndEnabled(chkForce);
+            }
+        }
+
+        /// <summary>
+        /// Set the controls for listings.
+        /// </summary>
+        private void SetItem()
+        {
+            if (chkItem.Checked)
+            {
+                SetControlCheckedAndDisabled(chkStation);
+            }
+            else
+            {
+                SetControlUncheckedAndEnabled(chkStation);
+            }
+        }
+
+        /// <summary>
+        /// Set the controls for station.
+        /// </summary>
+        private void SetStation()
+        {
+            if (chkStation.Checked)
+            {
+                SetControlCheckedAndDisabled(chkSystem);
+            }
+            else
+            {
+                SetControlUncheckedAndEnabled(chkSystem);
+            }
+        }
+
+        /// <summary>
         /// Set the controls for listings.
         /// </summary>
         private void SetListings()
@@ -440,12 +494,10 @@ namespace TDHelper
             if (chkListings.Checked)
             {
                 SetControlCheckedAndDisabled(chkItem);
-                SetControlCheckedAndDisabled(chkStation);
             }
             else
             {
                 SetControlUncheckedAndEnabled(chkItem);
-                SetControlUncheckedAndEnabled(chkStation);
             }
         }
 
@@ -462,6 +514,23 @@ namespace TDHelper
             else
             {
                 SetControlUncheckedAndEnabled(chkShip);
+                SetControlUncheckedAndEnabled(chkStation);
+            }
+        }
+
+        /// <summary>
+        /// Set the controls for upvend.
+        /// </summary>
+        private void SetUpvend()
+        {
+            if (chkUpvend.Checked)
+            {
+                SetControlCheckedAndDisabled(chkUpgrade);
+                SetControlCheckedAndDisabled(chkStation);
+            }
+            else
+            {
+                SetControlUncheckedAndEnabled(chkUpgrade);
                 SetControlUncheckedAndEnabled(chkStation);
             }
         }
@@ -492,45 +561,11 @@ namespace TDHelper
             {
                 SetControlUncheckedAndDisabled(chkListings);
                 SetControlCheckedAndDisabled(chkSkipvend);
-                SetControlUncheckedAndDisabled(chkUpvend);
             }
             else
             {
                 SetControlUncheckedAndEnabled(chkListings);
                 SetControlUncheckedAndEnabled(chkSkipvend);
-                SetControlUncheckedAndEnabled(chkUpvend);
-            }
-        }
-
-        /// <summary>
-        /// Set the controls for station.
-        /// </summary>
-        private void SetStation()
-        {
-            if (chkStation.Checked)
-            {
-                SetControlCheckedAndDisabled(chkSystem);
-            }
-            else
-            {
-                SetControlUncheckedAndEnabled(chkSystem);
-            }
-        }
-
-        /// <summary>
-        /// Set the controls for upvend.
-        /// </summary>
-        private void SetUpvend()
-        {
-            if (chkUpvend.Checked)
-            {
-                SetControlCheckedAndDisabled(chkUpgrade);
-                SetControlCheckedAndDisabled(chkStation);
-            }
-            else
-            {
-                SetControlUncheckedAndEnabled(chkUpgrade);
-                SetControlUncheckedAndEnabled(chkStation);
             }
         }
 


### PR DESCRIPTION
1: 
'item' should turn on 'station'.

----

2: 
'skipvend' and 'solo' should only turn off the options 'shipvend', 'upvend', and also, in the latter case, 'listings', and should not touch anything else.

Since turning off those three triggers the toggling of their parent options, we need to make sure the parent options stay on in the event that 'all' or 'clean' are enabled, when any of the three are turned off, by running the SetAll() immediately afterwards.

----

I would've done this in the last PR if I could see the results. Sadly, I still can't get the thing to successfully compile on my machine.